### PR TITLE
Improvement in #23, #22, #18

### DIFF
--- a/HoloOSCv2/Assets/Prefabs/Source.prefab
+++ b/HoloOSCv2/Assets/Prefabs/Source.prefab
@@ -94,7 +94,7 @@ Transform:
   m_GameObject: {fileID: 1327461097190608843}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalScale: {x: 0.18, y: 0.18, z: 0.18}
   m_Children:
   - {fileID: 8691013048217209521}
   m_Father: {fileID: 0}

--- a/HoloOSCv2/Assets/Scenes/SampleScene.unity
+++ b/HoloOSCv2/Assets/Scenes/SampleScene.unity
@@ -303,6 +303,9 @@ GameObject:
   - component: {fileID: 451885515}
   - component: {fileID: 451885516}
   - component: {fileID: 451885517}
+  - component: {fileID: 451885518}
+  - component: {fileID: 451885520}
+  - component: {fileID: 451885519}
   m_Layer: 0
   m_Name: OSCHandler
   m_TagString: OSCHandler
@@ -365,8 +368,63 @@ MonoBehaviour:
   _multicastLoopback: 1
   _bundleMessagesOnEndOfFrame: 0
   _splitBundlesAvoidingBufferOverflow: 1
-  _settingsFoldout: 0
+  _settingsFoldout: 1
   _messagesFoldout: 0
+--- !u!114 &451885518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451885514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b64988e220a2942f9856e0017b596ba8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _openOnAwake: 0
+  _udpBufferSize: 8192
+  _inspectorMessageEvent:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OscSimpl.OscMessageEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  _port: 80001
+  _mode: 0
+  _multicastAddress: 
+  _filterDuplicates: 1
+  _addTimeTagsToBundledMessages: 0
+  _dirtyMappings: 1
+  _mappings: []
+  _settingsFoldout: 0
+  _mappingsFoldout: 0
+  _messagesFoldout: 1
+--- !u!114 &451885519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451885514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69fd077d8477241d9950481d8ef70166, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &451885520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451885514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fb817750a98f394d81ef66be771e082, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sh: {fileID: 770322092}
+  oscIn: {fileID: 451885518}
 --- !u!1 &534669902
 GameObject:
   m_ObjectHideFlags: 0
@@ -541,6 +599,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   source: {fileID: 1327461097190608843, guid: 6c4bb493a80708e499e894c05a709d8c, type: 3}
   shell: {fileID: 863017277}
+  message: {fileID: 451885519}
   numberOfObjects: 8
 --- !u!4 &770322093
 Transform:
@@ -712,7 +771,7 @@ Transform:
   m_GameObject: {fileID: 863017277}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 770322093}
   m_RootOrder: 0
@@ -1149,6 +1208,31 @@ PrefabInstance:
         type: 3}
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: UpdateReceiver
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: Events.Array.data[1].Settings.Array.data[0].EventValue.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 770322092}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: Events.Array.data[1].Settings.Array.data[0].EventValue.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: UpdateSources
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: Events.Array.data[1].Settings.Array.data[0].EventValue.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: Events.Array.data[1].Settings.Array.data[0].EventValue.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: Events.Array.data[1].Settings.Array.data[0].EventValue.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 4607504470098667674, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}

--- a/HoloOSCv2/Assets/Scripts/OSCInput.cs
+++ b/HoloOSCv2/Assets/Scripts/OSCInput.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OSCInput : MonoBehaviour
+{
+    public SourceHandler sh;
+
+    [SerializeField]
+    private OscIn oscIn;
+
+    string address1 = "/MultiEncoder/inputSetting";
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        bool response = oscIn.Open(8001);
+        Debug.Log("Opening OSCin: " + response);
+    }
+
+    void OnEnable()
+    {
+
+        for (int i = 0; i < sh.getCount(); i++)
+        {
+            string azimuth = "/MultiEncoder/azimuth" + i.ToString();
+            string elevation = "/MultiEncoder/elevation" + i.ToString();
+            string gain = "/MultiEncoder/gain" + i.ToString();
+
+            oscIn.Map(azimuth, sh.UpdateThroughReaper);
+            oscIn.Map(elevation, sh.UpdateThroughReaper);
+            oscIn.Map(gain, sh.UpdateThroughReaper);
+        }
+    }
+}

--- a/HoloOSCv2/Assets/Scripts/OSCInput.cs.meta
+++ b/HoloOSCv2/Assets/Scripts/OSCInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fb817750a98f394d81ef66be771e082
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HoloOSCv2/Assets/Scripts/OSCMessageConverter.cs
+++ b/HoloOSCv2/Assets/Scripts/OSCMessageConverter.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class OSCMessageConverter : MonoBehaviour
+{
+    private OscMessage oscm;
+    private float value;
+    private string address;
+    private string commandString;
+    private string sourceNumberAsString;
+
+    public void extractFromMessage(OscMessage oscm)
+    {
+        oscm.TryGet(0, out value);
+        address = oscm.address;
+        sourceNumberAsString = Regex.Match(address, @"\d+").Value;
+        this.oscm = oscm;
+    }
+
+    public float GetValue() {
+        return value;
+    }
+
+    public int GetSourceNumber(){
+        return int.Parse(sourceNumberAsString);
+    }
+
+    public string GetCommandString() {
+        int pFrom = address.IndexOf("/MultiEncoder/") + "/MultiEncoder/".Length;
+        int pTo = address.LastIndexOf(sourceNumberAsString);
+        commandString = address.Substring(pFrom, pTo - pFrom);
+        return commandString;
+    }
+
+
+
+
+
+}

--- a/HoloOSCv2/Assets/Scripts/OSCMessageConverter.cs.meta
+++ b/HoloOSCv2/Assets/Scripts/OSCMessageConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69fd077d8477241d9950481d8ef70166
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HoloOSCv2/Assets/Scripts/SourceHandler.cs
+++ b/HoloOSCv2/Assets/Scripts/SourceHandler.cs
@@ -11,6 +11,14 @@ public class SourceHandler : MonoBehaviour
     float sourceRadius;
     float shellRadius;
 
+    OSCOutput output;
+    GameObject handler;
+    const string inputChannelNumber = "/MultiEncoder/inputSetting";
+
+    [SerializeField]
+    private OSCMessageConverter message;
+
+
     [SerializeField]
     private float numberOfObjects = 5;
 
@@ -18,6 +26,8 @@ public class SourceHandler : MonoBehaviour
        sourceRadius = source.GetComponent<SphereCollider>().radius;
        shellRadius = shell.GetComponent<SphereCollider>().radius;
         InstantiateObjects();
+        handler = GameObject.FindGameObjectWithTag("OSCHandler");
+        output = handler.GetComponent<OSCOutput>();
     }
 
     //Insantiates numberOfObjects Sources evenly around shell
@@ -27,15 +37,18 @@ public class SourceHandler : MonoBehaviour
         for (int i = 1; i <= numberOfObjects; i++) {
             float theta = (2 * Mathf.PI / numberOfObjects) * i;
             // scale has to be equal in all directions or algorithm has to be changed accordingly
-            spawnPos.x = Mathf.Cos(theta) * shellRadius * shell.transform.localScale.x;
-            spawnPos.z = Mathf.Sin(theta) * shellRadius * shell.transform.localScale.x;
+            float actualRadius = shellRadius * shell.transform.localScale.x;
+            spawnPos.x = Mathf.Cos(theta) * actualRadius;
+            spawnPos.z = Mathf.Sin(theta) * actualRadius;
             GameObject src = Instantiate(source, spawnPos, Quaternion.identity);
             src.name = "Source" + sources.Count;
             src.transform.parent = this.transform;
             src.GetComponent<SolverHandler>().TransformOverride = src.transform.parent;
+            src.GetComponent<RadialView>().MinDistance = actualRadius;
+            src.GetComponent<RadialView>().MaxDistance = actualRadius;
             src.GetComponent<SourceObject>().SetID(sources.Count);
             sources.Add(src);
-            
+
         }
     }
 
@@ -43,5 +56,55 @@ public class SourceHandler : MonoBehaviour
         //Destroy() the targeted Source 
     }
 
-   
+    public void UpdateSources()
+    {
+        string[] data = new string[2];
+
+        data[0] = inputChannelNumber;
+        data[1] = numberOfObjects.ToString();
+        output.SendMessage("SendOSCMessageToClient", data);
+
+        for (int i = 0; i < numberOfObjects; i++)
+        {
+            GameObject src = sources[i] as GameObject;
+            src.GetComponent<SourceObject>().sendMessageToOSCHandler();
+        }
+    }
+
+    public void UpdateThroughReaper(OscMessage oscm)
+    {
+        message.extractFromMessage(oscm);
+
+        GameObject src = sources[message.GetSourceNumber()] as GameObject;
+
+        if (message.GetCommandString() == "azimuth")
+        {
+            src.GetComponent<SourceObject>().setAzimuth(message.GetValue());
+        }
+        if (message.GetCommandString() == "elevation")
+        {
+            float elevation = message.GetValue();
+            if (elevation < -90)
+            {
+                src.GetComponent<SourceObject>().setElevation(elevation, 2 * (elevation + 90), true);
+            }
+            else if (elevation > 90)
+            {
+                src.GetComponent<SourceObject>().setElevation(elevation, 2 * (elevation - 90), true);
+            }
+            else
+            {
+                src.GetComponent<SourceObject>().setElevation(elevation, 0, false);
+            }
+        }
+        if (message.GetCommandString() == "gain")
+        {
+            src.GetComponent<SourceObject>().setGain(message.GetValue());
+        }
+    }
+
+    public int getCount()
+    {
+        return (int)numberOfObjects;
+    }
 }


### PR DESCRIPTION
- added OSCInput to receive elevation, azimuth and gain from Reaper.
- elevation above +- 90 degree is now displayable in unity
- the Shell can now be changed in scale, and the sources will generate still on its border, this wasnt doable because of the  RadialViewSolver with its Min- and Max-Distance-settings.

Still need to instatiate sources from reaper to unity with a sync-button because Reaper just messages on changes.